### PR TITLE
feat: threshold 조회 및 초과 시 API 로그 전송 기능 추가

### DIFF
--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/consumer/src/main/java/kr/cs/interdata/consumer/ConsumerApplication.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/ConsumerApplication.java
@@ -2,12 +2,11 @@ package kr.cs.interdata.consumer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-
+@EnableScheduling
 @SpringBootApplication
 public class ConsumerApplication {
-
-
 
 	public static void main(String[] args) {
 		SpringApplication.run(ConsumerApplication.class, args);

--- a/consumer/src/main/java/kr/cs/interdata/consumer/config/WebClientConfig.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/config/WebClientConfig.java
@@ -1,0 +1,31 @@
+package kr.cs.interdata.consumer.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${API_BASE_URL}")
+    private String baseUrl;
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder
+                // 기본 URL 설정
+                .baseUrl(baseUrl)
+                // 공통 헤더 설정
+                // json형식 데이터를 요청 및 수신한다.
+                .defaultHeaders(httpHeaders -> {
+                    httpHeaders.add(HttpHeaders.CONTENT_TYPE,
+                            MediaType.APPLICATION_JSON_VALUE);
+                })
+                // WebClient 생성
+                .build();
+    }
+
+}

--- a/consumer/src/main/java/kr/cs/interdata/consumer/dto/ThresholdRequest.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/dto/ThresholdRequest.java
@@ -1,0 +1,24 @@
+package kr.cs.interdata.consumer.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ThresholdRequest {
+    private String type;
+    private String metric;
+    private Double value;
+    private LocalDateTime detected_at;
+
+    public ThresholdRequest(String type, String metric, Double value, LocalDateTime detected_at) {
+        this.type = type;
+        this.metric = metric;
+        this.value = value;
+        this.detected_at = detected_at;
+    }
+
+
+}

--- a/consumer/src/main/java/kr/cs/interdata/consumer/infra/ThresholdFetcher.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/infra/ThresholdFetcher.java
@@ -1,0 +1,85 @@
+package kr.cs.interdata.consumer.infra;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+/**
+ * 주기적으로 외부 API에서 경계값을 조회하고 이를 ThresholdStore에 업데이트하는 클래스입니다.
+ *
+ * 이 클래스는 `@Scheduled` 어노테이션을 사용하여 1분마다 외부 API에서 경계값을 가져와
+ * 이를 `ThresholdStore`에 저장하거나 갱신합니다. API 호출 및 응답 처리 과정은 비동기적으로 이루어집니다.
+ *
+ * 주요 기능:
+ * - 1분마다 외부 API에서 경계값을 조회하여 `ThresholdStore`에 반영
+ * - 경계값이 0 이하인 경우 경고 메시지를 로그에 기록하고, 기존 값을 유지
+ * - 정상적인 값이 조회되면 해당 값을 `ThresholdStore`에 업데이트
+ *
+ * 이 클래스는 Spring의 `@Scheduled` 어노테이션을 사용하여 주기적인 작업을 수행하고,
+ * `WebClient`를 사용해 외부 API와 비동기적으로 통신합니다.
+ */
+@Component
+public class ThresholdFetcher {
+
+    // 로그 변수
+    private final Logger logger = LoggerFactory.getLogger(ThresholdFetcher.class);
+
+
+    private final WebClient webClient;
+    private final ThresholdStore thresholdStore;
+
+    /**
+     * ThresholdFetcher 생성자
+     *
+     * @param webClient 외부 API와의 통신을 위한 WebClient
+     * @param thresholdStore 경계값을 관리하는 ThresholdStore
+     */
+    @Autowired
+    public ThresholdFetcher(WebClient webClient, ThresholdStore thresholdStore) {
+        this.webClient = webClient;
+        this.thresholdStore = thresholdStore;
+    }
+
+    /**
+     * 1분마다 외부 API에서 경계값을 조회하고, 이를 ThresholdStore에 업데이트하는 메서드입니다.
+     *
+     * @note
+     * 이 메서드는 `@Scheduled` 어노테이션을 통해 1분마다 실행되며, 경계값을 조회한 후,
+     * 그 값이 0 이하일 경우 경고 메시지를 출력하고 기존 값을 유지합니다.
+     * 그 외의 경우에는 `thresholdStore`에 값을 업데이트합니다.
+     */
+    @Scheduled(fixedRate = 60000)
+    public void fetchThreshold() {
+        String url = "/api/metrics/threshold-check";
+
+        webClient
+                .get()      // http get 요청을 시작함
+                .uri(url)   // 요청할 경로
+                .retrieve() // 응답을 추출할 준비를 함.
+                // 응답 바디를 비동기적으로 Mono 타입으로 변환한다. (Map<"머신 타입", Map<"메트릭 이름", "임계값">>)
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Map<String, Double>>>() {})
+                // 에러 로그
+                .doOnError(error -> logger.warn("기준값 조회 실패: {}", error.getMessage()))
+                // 응답으로 받은 Map
+                // thresholdStore에 경계값 반영한다.
+                .subscribe(response -> {
+                    response.forEach((type, metrics) -> {
+                        metrics.forEach((metric, value) -> {
+                            if (value > 0) {
+                                thresholdStore.updateThreshold(type, metric, value);
+                            } else {
+                                logger.warn("기준값 0 이하: {} -> {} = {} → 기존 유지", type, metric, value);
+                            }
+                        });
+                    });
+                });
+    }
+
+}
+

--- a/consumer/src/main/java/kr/cs/interdata/consumer/infra/ThresholdStore.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/infra/ThresholdStore.java
@@ -1,0 +1,55 @@
+package kr.cs.interdata.consumer.infra;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ThresholdStore {
+
+    // 머신 타입(host/container) → 메트릭 이름 → 임계값 을 저장하는 맵
+    private final Map<String, Map<String, Double>> thresholdMap = new ConcurrentHashMap<>();
+
+    /**
+     * 특정 타입(type)에 대해 메트릭(metric)의 임계값(value)을 갱신한다.
+     * 해당 type이 처음 추가되는 경우, 내부적으로 새로운 Map을 생성한다.
+     * 예시 : thresholdStore.updateThreshold("host", "cpu", 80.0);
+     *
+     * @param type   머신 종류 (예: "host" 또는 "container")
+     * @param metric 메트릭 이름 (예: "cpu", "memory" 등)
+     * @param value  임계값 (예: 80.0)
+     */
+    public void updateThreshold(String type, String metric, Double value) {
+        thresholdMap.computeIfAbsent(type, k -> new ConcurrentHashMap<>())
+                .put(metric, value);
+    }
+
+    /**
+     * 특정 타입(type)과 메트릭(metric)에 해당하는 임계값을 반환한다.
+     * 값이 없으면 null을 반환한다.
+     * 예시 : thresholdStore.getThreshold("host", "cpu"); // → 80.0
+     *
+     * @param type   머신 종류
+     * @param metric 메트릭 이름
+     * @return 임계값 또는 null
+     */
+    public Double getThreshold(String type, String metric) {
+        return Optional.ofNullable(thresholdMap.get(type))
+                .map(m -> m.get(metric))
+                .orElse(null);
+    }
+
+    /**
+     * 특정 타입(type)에 대한 모든 메트릭들의 임계값 Map을 반환한다.
+     * 값이 없으면 빈 맵을 반환한다.
+     *
+     * @param type 머신 종류
+     * @return 해당 타입의 (메트릭 → 임계값) Map
+     */
+    public Map<String, Double> getThresholdsFor(String type) {
+        return thresholdMap.getOrDefault(type, Collections.emptyMap());
+    }
+}

--- a/consumer/src/main/java/kr/cs/interdata/consumer/service/KafkaConsumerService.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/service/KafkaConsumerService.java
@@ -2,6 +2,7 @@ package kr.cs.interdata.consumer.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.cs.interdata.consumer.infra.ThresholdStore;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -11,6 +12,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -18,10 +25,17 @@ public class KafkaConsumerService {
 
     private final Logger logger = LoggerFactory.getLogger(KafkaConsumerService.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ThresholdStore thresholdStore;
+    private final ThresholdService thresholdService;
 
+    @Autowired
+    public KafkaConsumerService(ThresholdStore thresholdStore, ThresholdService thresholdService) {
+        this.thresholdStore = thresholdStore;
+        this.thresholdService = thresholdService;
+    }
 
     /**
-     * 	- Kafka로부터 배치 메시지를 수신하고 처리하는 메서드
+     * 	- Kafka - "host"로부터 배치 메시지를 수신하고 처리하는 메서드
      * 	type : BATCH
      * 	listener Type : BatchMessageListener
      * 	method parameter : onMessage(ConsumerRecords<K, V> data)
@@ -29,28 +43,49 @@ public class KafkaConsumerService {
      * @param records // 지정 토픽에서 받아온 데이터 list
      */
     @KafkaListener(
-            topics = "${KAFKA_TOPIC_METRICS}",
+            topics = "${KAFKA_TOPIC_HOST}",
             groupId = "${KAFKA_GROUP_ID_STORAGE_GROUP}",
             containerFactory = "customContainerFactory"
     )
-    public void batchListener(ConsumerRecords<String, String> records, Acknowledgment ack) {
+    public void batchListenerForHost(ConsumerRecords<String, String> records, Acknowledgment ack) {
+        List<Mono<Void>> asyncTasks = new ArrayList<>(); // 비동기 작업을 저장할 리스트
+
         for (ConsumerRecord<String, String> record : records) {
             String id = record.key();
             String json = record.value();
 
             try {
-                JsonNode rootNode = parseJson(json, record);  // JSON 파싱을 메서드로 분리
+                JsonNode rootNode = parseJson(json);  // JSON 파싱을 메서드로 분리
                 JsonNode metricsNode = rootNode.get("metrics");
-                JsonNode containerIdNode = rootNode.get("containerId");
 
-                if (metricsNode == null || containerIdNode == null) {
-                    throw new IllegalArgumentException("필수 필드(metrics 또는 containerId)가 누락된 메시지입니다.");
-                }
 
                 // WebSocket으로 데이터 전달 예정
-                // TODO: 도메인 생성 및 프론트 설정 완료 후 삽입 예정
+                // TODO: 도메인 생성 및 설정 완료 후 삽입 예정
 
-                logger.info("Kafka Record 처리 성공: {}", record.toString());
+                // timestamp를 LocalDateTime으로 변환
+                String timestampStr = rootNode.get("timestamp").asText();
+                LocalDateTime violationTime = LocalDateTime.parse(timestampStr, DateTimeFormatter.ISO_DATE_TIME);
+
+                // metricsNode에서 각 메트릭 데이터를 추출하여 임계값 초과 여부를 확인하고 처리
+                metricsNode.fields().forEachRemaining(entry -> {
+                    String metricName = entry.getKey(); // 메트릭 이름
+                    double metricValue = entry.getValue().asDouble(); // 메트릭 값
+
+                    // thresholdStore에서 해당 메트릭의 임계값을 가져옴
+                    Double threshold = thresholdStore.getThreshold(id, metricName);
+
+                    // 임계값이 설정되지 않은 경우(기본값 100.0) 혹은 임계값 초과 시 API로 전송
+                    if (threshold != null && metricValue > threshold) {
+                        logger.warn("임계값 초과: {} -> {} = {} (기준값: {})", id, metricName, metricValue, threshold);
+
+                        // 임계값 초과 데이터를 API 백엔드로 전송
+                        // TODO: API 호출은 대기시간이 있을 수 있으므로, 비동기 작업 처리로 변경 예정
+                        thresholdService.sendThresholdViolation(id, metricName, metricValue, violationTime);
+
+                    }
+                });
+
+                logger.info("Kafka Record(Host) 처리 성공: {}", record.toString());
 
             } catch (InvalidJsonException e) {
                 logger.error("잘못된 JSON 형식 - key: {}, value: {}, error: {}", record.key(), record.value(), e.getMessage());
@@ -66,8 +101,77 @@ public class KafkaConsumerService {
         ack.acknowledge();
     }
 
+    /**
+     * 	- Kafka - "container"로부터 배치 메시지를 수신하고 처리하는 메서드
+     * 	type : BATCH
+     * 	listener Type : BatchMessageListener
+     * 	method parameter : onMessage(ConsumerRecords<K, V> data)
+     *
+     * @param records // 지정 토픽에서 받아온 데이터 list
+     */
+    @KafkaListener(
+            topics = "${KAFKA_TOPIC_CONTAINER}",
+            groupId = "${KAFKA_GROUP_ID_STORAGE_GROUP}",
+            containerFactory = "customContainerFactory"
+    )
+    public void batchListenerForContainer(ConsumerRecords<String, String> records, Acknowledgment ack) {
+        List<Mono<Void>> asyncTasks = new ArrayList<>(); // 비동기 작업을 저장할 리스트
+
+        for (ConsumerRecord<String, String> record : records) {
+            String id = record.key();
+            String json = record.value();
+
+            try {
+                JsonNode rootNode = parseJson(json);  // JSON 파싱을 메서드로 분리
+                JsonNode metricsNode = rootNode.get("metrics");
+
+
+                // WebSocket으로 데이터 전달 예정
+                // TODO: 도메인 생성 및 설정 완료 후 삽입 예정
+
+                // timestamp를 LocalDateTime으로 변환
+                String timestampStr = rootNode.get("timestamp").asText();
+                LocalDateTime violationTime = LocalDateTime.parse(timestampStr, DateTimeFormatter.ISO_DATE_TIME);
+
+                // metricsNode에서 각 메트릭 데이터를 추출하여,
+                // 임계값 초과 여부를 확인하고 처리한다.
+                metricsNode.fields().forEachRemaining(entry -> {
+                    String metricName = entry.getKey(); // 메트릭 이름
+                    double metricValue = entry.getValue().asDouble(); // 메트릭 값
+
+                    // thresholdStore에서 해당 메트릭의 임계값을 가져옴
+                    Double threshold = thresholdStore.getThreshold(id, metricName);
+
+                    // 임계값이 설정되지 않은 경우(기본값 100.0) 혹은 임계값 초과 시 API로 전송
+                    if (threshold != null && metricValue > threshold) {
+                        logger.warn("임계값 초과: {} -> {} = {} (기준값: {})", id, metricName, metricValue, threshold);
+
+                        // 임계값 초과 데이터를 API 백엔드로 전송
+                        // TODO: API 호출은 대기시간이 있을 수 있으므로, 비동기 작업 처리로 변경 예정
+                        thresholdService.sendThresholdViolation(id, metricName, metricValue, violationTime);
+
+                    }
+                });
+
+                logger.info("Kafka Record(Container) 처리 성공: {}", record.toString());
+
+            } catch (InvalidJsonException e) {
+                logger.error("잘못된 JSON 형식 - key: {}, value: {}, error: {}", record.key(), record.value(), e.getMessage());
+            } catch (IllegalArgumentException e) {
+                logger.warn("JSON 필드 누락 - key: {}, value: {}, 원인: {}", record.key(), record.value(), e.getMessage());
+            } catch (Exception e) {
+                logger.error("예상치 못한 예외 발생 - key: {}, value: {}", record.key(), record.value(), e);
+            }
+
+        }
+
+        // 수동 커밋
+        ack.acknowledge();
+    }
+
+
     // json 파싱
-    private JsonNode parseJson(String json, ConsumerRecord<String, String> record) {
+    private JsonNode parseJson(String json) {
         try {
             return objectMapper.readTree(json);
         } catch (Exception e) {

--- a/consumer/src/main/java/kr/cs/interdata/consumer/service/ThresholdService.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/service/ThresholdService.java
@@ -1,0 +1,55 @@
+package kr.cs.interdata.consumer.service;
+
+
+import kr.cs.interdata.consumer.dto.ThresholdRequest;
+import kr.cs.interdata.consumer.infra.ThresholdFetcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+
+@Service
+public class ThresholdService {
+
+    // 로그 변수
+    private final Logger logger = LoggerFactory.getLogger(ThresholdFetcher.class);
+
+    private final WebClient webClient;
+
+    @Autowired
+    public ThresholdService(WebClient webClient) {
+        this.webClient = webClient;  // 이미 설정된 WebClient를 주입받음
+    }
+
+    /**
+     * 임계값 초과 데이터를 API 백엔드로 전송하는 메서드.
+     *
+     * @param host     : 메시지를 보낸 호스트
+     * @param metric   : 메트릭 이름
+     * @param value    : 임계값을 넘은 값
+     * @param timestamp: 임계값을 넘은 시각
+     */
+    public void sendThresholdViolation(String host, String metric, Double value, LocalDateTime timestamp) {
+        ThresholdRequest request = new ThresholdRequest(host, metric, value, timestamp);
+        String url = "/api/metrics/threshold-violations";
+
+        // API 백엔드로 POST 요청을 보내고 응답을 처리
+        webClient.post()
+                .uri(url)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(Void.class)  // 응답은 없으므로 처리하지 않음
+                .doOnError(error -> {
+                    // 에러 로그 처리
+                    logger.warn("임계값 초과 전송 실패: " + error.getMessage());
+                })
+                .doOnTerminate(() -> {
+                    // 성공적으로 요청을 마친 후의 처리
+                    logger.info("임계값 초과 데이터 전송 완료");
+                })
+                .subscribe();  // 비동기 방식으로 호출
+    }
+}

--- a/consumer/src/main/resources/application.properties
+++ b/consumer/src/main/resources/application.properties
@@ -4,18 +4,6 @@ spring.application.name=consumer
 server.port=8000
 spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVER}
 
-# DB settings
-spring.datasource.url=${DATABASE_URL}
-spring.datasource.username=${DATABASE_USERNAME}
-spring.datasource.password=${DATABASE_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
-# jpa settings
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
-
 # Consumer settings
 spring.kafka.consumer.group-id=${GROUP_ID}
 spring.kafka.consumer.auto-offset-reset=earliest

--- a/consumer/src/main/resources/properties/env.properties
+++ b/consumer/src/main/resources/properties/env.properties
@@ -1,10 +1,9 @@
-DATABASE_URL=jdbc:mysql://localhost:3306/monitoring_db
-DATABASE_USERNAME=root
-DATABASE_PASSWORD=hyaebin1104!
-
 GROUP_ID=data-stroage-group
 BOOTSTRAP_SERVER=localhost:9094
 
-KAFKA_TOPIC_METRICS=monitoring.metrics.dev.json
+KAFKA_TOPIC_HOST=monitoring.host.dev.json
+KAFKA_TOPIC_CONTAINER=monitoring.container.dev.json
 KAFKA_GROUP_ID_STORAGE_GROUP=data-storage-group
 
+
+API_BASE_URL=http://domain:8081


### PR DESCRIPTION
📌 개요
Kafka에서 수신한 메트릭 데이터가 임계값(threshold)을 초과할 경우, 해당 이상치 정보를 API 서버로 전송하는 기능을 추가했습니다.

✅ 주요 변경 사항
ThresholdStore에서 메트릭별 임계값 조회 기능 사용(임계값은 ThresholdFetcher에서 스케쥴러를 이용해 1분간격으로 갱신한다.)
Kafka 배치 리스너에서 metrics를 순회하며 임계값 초과 여부 확인
초과된 항목은 ThresholdService를 통해 api-backend로 전송
예외 처리 및 로그 메시지 추가

☑️ 기타
관련 환경변수 및 WebClient 설정은 WebClientConfig에서 관리