### PR TITLE
feat : Add CPU usage measurement using cgroup cpuacct.usage

### DIFF
--- a/data-collector/build.gradle
+++ b/data-collector/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'com.github.oshi:oshi-core:6.4.5'
     implementation 'com.google.code.gson:gson:2.10.1'
     //implementation files('libs/gson-2.10.1.jar')
+    implementation "com.h2database:h2"
 }
 
 tasks.named('test') {

--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
@@ -8,25 +8,21 @@ public class DataCollectorApplication {
 
     public static void main(String[] args) {
 
-        String filePath = "C:/Users/chaee/Desktop/knu-capstone-design2/metrics-backend/data-collector/test.txt";
+            //String filePath = "C:/Users/chaee/Desktop/knu-capstone-design2/metrics-backend/data-collector/test.txt";
 
-        File file = new File(filePath);
-        System.out.println("파일 존재 여부: " + file.exists());
-        System.out.println("절대 경로: " + file.getAbsolutePath());
+            while (true) {
+                String json = ContainerResourceMonitor.collectContainerResources();
+                System.out.println("=== 컨테이너 리소스 수집 결과 ===");
+                System.out.println(json);
 
-        String fileContent = ContainerResourceMonitor.readFile(filePath);
-        System.out.println("readFile 결과: " + fileContent);
+                try {
+                    Thread.sleep(5000); // 5초마다 반복
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    System.out.println("스레드가 인터럽트되었습니다.");
+                    break;
+                }
+            }
 
-        Long longValue = ContainerResourceMonitor.readLongFromFile(filePath);
-        System.out.println("readLongFromFile 결과: " + longValue);
-
-        System.out.println("현재 작업 디렉토리: " + System.getProperty("user.dir"));
-
-        // 스프링 부트 애플리케이션 실행
-        //SpringApplication.run(DataCollectorApplication.class, args);
-
-        String json = ContainerResourceMonitor.collectContainerResources();
-        System.out.println("=== 컨테이너 리소스 수집 결과 ===");
-        System.out.println(json);
     }
 }


### PR DESCRIPTION
## cgroup의 cpuacct.usage 파일을 이용해서 1초 간격으로 CPU 사용량을 측정하는 기능 추가

- 1초 간격으로 누적 cpu 사용량을 2번 읽고 그 차이를 이욯해 1초 동안 CPU 사용률을 계산함.

- /sys/fs/cgroup/cpuacct/cpuacct.usage 파일은 컨테이너 혹은 프로세스가 지금까지 사용한 누적 CPU 시간(나노초 단위)를 기록

- 사용률이 json에 담아지도록 구현해놓음.

- 기본값을 -1로 설정해둬서 두 값이 모두 null이면 -1이 나옴.

- 테스트 코드는 5초마다 한번씩 정보를 들고 오게 설정해둠.
1. 먼저 gradle로 빌드
./gradlew build

 2. 도커 이미지 빌드
docker build -t resource-monitor .

 3. 도커 컨테이너 실행
docker run --privileged --name test-monitor resource-monitor

4. 결과 확인
![image](https://github.com/user-attachments/assets/4076bbb5-224b-4b39-977a-79382875fa25)


참고자료 : [https://velog.io/@hsh_124/cgroup-%EC%9D%84-%ED%86%B5%ED%95%B4-%EC%BB%A8%ED%85%8C%EC%9D%B4%EB%84%88%EC%9D%98-%EB%A6%AC%EC%86%8C%EC%8A%A4-%ED%99%95%EC%9D%B8%ED%95%98%EA%B8%B0
]