### PR TITLE
feat: add memory usage data collection using cgroup file

### DIFF
--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/ContainerResourceMonitor.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/ContainerResourceMonitor.java
@@ -69,6 +69,7 @@ public class ContainerResourceMonitor {
             //hostname을 얻는 과정에서 오류가 발생하면 에러 로그를 남기고 containerID는 unknown으로 남음
             logger.log(Level.SEVERE, "Failed to get containerId (hostname)", e);
         }
+        jsonMap.put("containerId", containerId);//JSON 데이터에 포함 시킴
 
         //cpu 사용량 측정
         //1초 간격으로 누적 cpu 사용량을 2번 읽고 그 차이를 이욯해 1초 동안 CPU 사용률을 계산함.
@@ -97,7 +98,46 @@ public class ContainerResourceMonitor {
         }
         jsonMap.put("cpuUsage", cpuUsagePercent);
 
-        jsonMap.put("containerId", containerId);//JSON 데이터에 포함 시킴
+        // 메모리 정보 수집
+        //memory.limit_in_bytes: 컨테이너에 할당된 최대 메모리
+        //memory.usage_in_bytes: 현재 사용중인 메모리
+        /**
+        Long memoryLimit = readLongFromFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+        if (memoryLimit == null) {
+            memoryLimit = readLongFromFile("/sys/fs/cgroup/memory.max");
+        }
+        **/
+        Long memoryUsage = readLongFromFile("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+        if (memoryUsage == null) {
+            memoryUsage = readLongFromFile("/sys/fs/cgroup/memory.current");
+        }
+        /**
+        Long memoryFree=null;
+        if (memoryLimit != null && memoryUsage != null) {
+            memoryFree = memoryUsage - memoryLimit;
+        }
+         **/
+        //JSON에 값 넣기
+        /**
+        if (memoryFree!=null) {
+            jsonMap.put("memoryTotalBytes",memoryLimit);
+        }else{
+            jsonMap.put("memoryTotalBytes",-1);
+        }
+        **/
+        if (memoryUsage!=null){
+            jsonMap.put("memoryUsedBytes",memoryUsage);
+        }else{
+            jsonMap.put("memoryUsedBytes",-1);
+        }
+        /**
+        if (memoryFree!=null){
+            jsonMap.put("memoryFreeBytes",memoryFree);
+        }else{
+            jsonMap.put("memoryFreeBytes",-1);
+        }
+        **/
+
         return new Gson().toJson(jsonMap);
     }
 


### PR DESCRIPTION
## 컨테이너 내의 메모리 사용량 가져오기
- cgroup의 memory.usage_in_bytes를 활용하여 메모리 사용량 가져옴.
- 밑에 null이면 다른 곳에서 받아오게 하는데 그 이유는 v1과 v2의 경로가 다르기 때문. 
- v1,v2 관련 내용은 자료 참고해주세용 : [https://velog.io/@hsh_124/cgroup-%EC%9D%84-%ED%86%B5%ED%95%B4-%EC%BB%A8%ED%85%8C%EC%9D%B4%EB%84%88%EC%9D%98-%EB%A6%AC%EC%86%8C%EC%8A%A4-%ED%99%95%EC%9D%B8%ED%95%98%EA%B8%B0](url)
- 전체 메모리와 free 메모리는 주석처리해 놓은 이유가 컨테이너 리소스를 수집할 때 컨테이너에 메모리 제한을 따로 설정하지 않으면 호스트 머신의 전체 메모리를 제한 없이 사용할 수 있게 되는데 이때 cgroup에서 엄청 큰 값을 보여줌.
- 호스트 메모리 크기 자체가 아니라 제한 없음을 의미하는 값임, 실제 호스트 메모리는 물리적으로 정해져 있지만 cgroup은 컨테이너가 이론상 얼마든지 쓸 수 있다는 의미로 저 값을 기록함. 
- 따라서 내가 생각했었던것과는 조금 다른 방향으로 값이 나와서 이 부분을 더 생각해보고 싶어서 주석으로 달아놨음.
![image](https://github.com/user-attachments/assets/020db958-8653-4108-bff7-2b5e8ea63333)
- 주석 처리 안했을때 출력되는 값
![image](https://github.com/user-attachments/assets/77b54239-1b8c-4350-8bff-1e5ba53eff45)
- 현재 출력되는 출력값