### PR TITLE
Refactor network I/O, network speed, and disk I/O to be calculated ba…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ subprojects {
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testImplementation 'org.springframework.kafka:spring-kafka-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        implementation files('libs/gson-2.10.1.jar')
     }
 
     tasks.named('test') {

--- a/data-collector/build.gradle
+++ b/data-collector/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'application'
 }
 
 group = 'kr.cs.interdata'
@@ -11,6 +12,14 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+springBoot {
+    mainClass = 'kr.cs.interdata.datacollector.ResourceMonitorDaemon'
+}
+
+application {
+    mainClass = 'kr.cs.interdata.datacollector.ResourceMonitorDaemon'
 }
 
 configurations {
@@ -42,7 +51,6 @@ dependencies {
 
     implementation 'com.github.oshi:oshi-core:6.4.5'
     implementation 'com.google.code.gson:gson:2.10.1'
-    //implementation files('libs/gson-2.10.1.jar')
     implementation "com.h2database:h2"
 }
 

--- a/data-collector/settings.gradle
+++ b/data-collector/settings.gradle
@@ -1,1 +1,2 @@
+include 'data-collector'
 rootProject.name = 'data-collector'

--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/ResourceMonitorDaemon.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/ResourceMonitorDaemon.java
@@ -1,0 +1,151 @@
+package kr.cs.interdata.datacollector;
+
+import com.google.gson.Gson;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ResourceMonitorDaemon {
+    public static void main(String[] args) throws Exception {
+        LocalHostResourceMonitor monitor = new LocalHostResourceMonitor();
+
+        // 이전 디스크 I/O 값 저장
+        long prevDiskReadBytes = 0;
+        long prevDiskWriteBytes = 0;
+
+        // 이전 네트워크 인터페이스별 값 저장
+        Map<String, Long> prevNetRecv = new HashMap<>();
+        Map<String, Long> prevNetSent = new HashMap<>();
+
+        ObjectMapper prettyMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+        while (true) {
+            String jsonStr = monitor.getResourcesAsJson();
+            Map<String, Object> resourceMap = new Gson().fromJson(jsonStr, Map.class);
+
+            // 1. 디스크 변화량 계산
+            long currDiskReadBytes = ((Number) resourceMap.get("diskReadBytes")).longValue();
+            long currDiskWriteBytes = ((Number) resourceMap.get("diskWriteBytes")).longValue();
+            long deltaDiskRead = currDiskReadBytes - prevDiskReadBytes;
+            long deltaDiskWrite = currDiskWriteBytes - prevDiskWriteBytes;
+
+            // 2. 네트워크 변화량 계산
+            Map<String, Object> netInfo = (Map<String, Object>) resourceMap.get("network");
+            Map<String, Map<String, Object>> netDelta = new HashMap<>();
+            for (String iface : netInfo.keySet()) {
+                Map<String, Object> ifaceInfo = (Map<String, Object>) netInfo.get(iface);
+                long currRecv = ((Number) ifaceInfo.get("bytesReceived")).longValue();
+                long currSent = ((Number) ifaceInfo.get("bytesSent")).longValue();
+                long prevRecv = prevNetRecv.getOrDefault(iface, currRecv);
+                long prevSent = prevNetSent.getOrDefault(iface, currSent);
+
+                long deltaRecv = currRecv - prevRecv;
+                long deltaSent = currSent - prevSent;
+
+                // 네트워크 속도(Bps, 초당 바이트)
+                long rxBps = deltaRecv / 5;
+                long txBps = deltaSent / 5;
+
+                Map<String, Object> ifaceDelta = new HashMap<>();
+                ifaceDelta.put("rxBytesDelta", deltaRecv);
+                ifaceDelta.put("txBytesDelta", deltaSent);
+                ifaceDelta.put("rxBps", rxBps); // 초당 받은 바이트
+                ifaceDelta.put("txBps", txBps); // 초당 보낸 바이트
+                netDelta.put(iface, ifaceDelta);
+
+                prevNetRecv.put(iface, currRecv);
+                prevNetSent.put(iface, currSent);
+            }
+
+            // 3. 필요 없는 누적값(디스크/네트워크) 삭제
+            resourceMap.remove("diskReadBytes");
+            resourceMap.remove("diskWriteBytes");
+            resourceMap.remove("network");
+
+            // 4. 변화량만 추가
+            resourceMap.put("diskReadBytesDelta", deltaDiskRead);
+            resourceMap.put("diskWriteBytesDelta", deltaDiskWrite);
+            resourceMap.put("networkDelta", netDelta);
+
+            // 5. 예쁘게 출력
+            String prettyJson = prettyMapper.writeValueAsString(resourceMap);
+            //System.out.println("=== 로컬 호스트 리소스 수집 결과 ===");
+            System.out.println(prettyJson);
+
+            // 6. 이전값 갱신
+            prevDiskReadBytes = currDiskReadBytes;
+            prevDiskWriteBytes = currDiskWriteBytes;
+
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException ie) {
+                // 인터럽트가 발생하면 로그만 남기고 계속 반복
+                System.out.println("Interrupted, but monitoring continues.");
+            }
+        }
+    }
+}
+
+       /**
+        //무한 루프 : 5초마다 리소스 데이터 수집 및 출력
+        while (true) {
+            // 현재 리소스 전체 누적값(JSON 문자열) 파싱
+            String jsonStr = monitor.getResourcesAsJson();
+            Map<String, Object> resourceMap = new Gson().fromJson(jsonStr, Map.class);
+
+            // 2. 디스크 변화량 계산
+            long currDiskReadBytes = ((Number) resourceMap.get("diskReadBytes")).longValue();
+            long currDiskWriteBytes = ((Number) resourceMap.get("diskWriteBytes")).longValue();
+            long deltaDiskRead = currDiskReadBytes - prevDiskReadBytes;
+            long deltaDiskWrite = currDiskWriteBytes - prevDiskWriteBytes;
+
+            // 3. 네트워크 변화량 계산
+            Map<String, Object> netInfo = (Map<String, Object>) resourceMap.get("network");
+            Map<String, Map<String, Object>> netDelta = new HashMap<>();
+            for (String iface : netInfo.keySet()) {
+                Map<String, Object> ifaceInfo = (Map<String, Object>) netInfo.get(iface);
+                long currRecv = ((Number) ifaceInfo.get("bytesReceived")).longValue();
+                long currSent = ((Number) ifaceInfo.get("bytesSent")).longValue();
+                long prevRecv = prevNetRecv.getOrDefault(iface, currRecv);
+                long prevSent = prevNetSent.getOrDefault(iface, currSent);
+
+                long deltaRecv = currRecv - prevRecv;
+                long deltaSent = currSent - prevSent;
+
+                Map<String, Object> ifaceDelta = new HashMap<>();
+                ifaceDelta.put("rxBytesDelta", deltaRecv);
+                ifaceDelta.put("txBytesDelta", deltaSent);
+                netDelta.put(iface, ifaceDelta);
+
+                prevNetRecv.put(iface, currRecv);
+                prevNetSent.put(iface, currSent);
+            }
+
+            // 4. 최종 JSON에 변화량 정보 추가
+            resourceMap.put("diskReadBytesDelta", deltaDiskRead);
+            resourceMap.put("diskWriteBytesDelta", deltaDiskWrite);
+            resourceMap.put("networkDelta", netDelta);
+
+            // 5. 예쁘게 출력(Pretty Print)
+            String prettyJson = prettyMapper.writeValueAsString(resourceMap);
+            System.out.println("=== 로컬 호스트 리소스 수집 결과 ===");
+            System.out.println(prettyJson);
+
+            // 6. 이전값 갱신
+            prevDiskReadBytes = currDiskReadBytes;
+            prevDiskWriteBytes = currDiskWriteBytes;
+
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                System.out.println("스레드가 인터럽트되었습니다.");
+                break;
+            }
+        }
+    }
+}
+**/


### PR DESCRIPTION
## 로컬 호스트 리소스 변화량 기반 네트워크/디스크 I/O 로 변경

### 주요 변경 사항

- 기존 누적값 기반의 디스크 및 네트워크 리소스 수집 방식을 변화량 기반으로 변경
- 디스크 I/O (읽기/쓰기) 변화량을 5초 간격으로 계산하여 diskReadBytesDelta, diskWriteBytesDelta로 출력
- 네트워크 인터페이스별 수신/송신 바이트 변화량(rxBytesDelta, txBytesDelta)과 이를 기반으로 한 초당 속도(rxBps, txBps)를 계산하여 networkDelta 포함시킴
- 누적값 필드(diskReadBytes, diskWriteBytes, network)는 출력 JSON에서 삭제
- 5초 간격으로 지속적으로 모니터링하며 출력할 수 있도록 무한 루프

### 이유

- 모니터링 시스템 또는 실시간 리소스 수집 시  누적값보다 시간당 변화량이 더 직관적이며 분석에 용이할거라 팀원들과 판단

### 실행 방법

- ./gradlew run으로 실행시키면 됨

### 테스트
![image](https://github.com/user-attachments/assets/a293829e-2fd0-45d2-854f-83234e4b4b4d)


