### PR TITLE
feat: add network receive and transmit speed metrics

### DIFF
--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
@@ -39,9 +39,15 @@ public class DataCollectorApplication {
                 long deltaRecv = currRecv - prevRecv;
                 long deltaSent = currSent - prevSent;
 
+                // 네트워크 속도(Bps, 초당 바이트)
+                long rxBps = deltaRecv / 5;
+                long txBps = deltaSent / 5;
+
                 Map<String, Object> ifaceDelta = new HashMap<>();
                 ifaceDelta.put("rxBytesDelta", deltaRecv);
                 ifaceDelta.put("txBytesDelta", deltaSent);
+                ifaceDelta.put("rxBps", rxBps); // 초당 받은 바이트
+                ifaceDelta.put("txBps", txBps); // 초당 보낸 바이트
                 netDelta.put(iface, ifaceDelta);
 
                 prevNetRecv.put(iface, currRecv);


### PR DESCRIPTION
## 컨테이너의 네트워크 수신 및 송신 속도를 초당 바이트 단위(Bps, Bytes per second)로 계산하는 기능을 추가

- 네트워크 변화량을 기준으로 속도(Bps)를 계산:
    속도(Bps) = 변화량(Byte) / 측정 주기(초)
- 새로 추가된 항목:
    - rxBps: 초당 수신된 바이트 수
    - txBps: 초당 송신된 바이트 수

예시 코드:
```java
long rxBps = deltaRecv / intervalSeconds;
long txBps = deltaSent / intervalSeconds;
```

실행 결과

![image](https://github.com/user-attachments/assets/61a165af-f6c4-4259-8ac3-6d063b988a81)