### PR TITLE
feat: send container resource metrics to Kafka

### DIFF
--- a/consumer/settings.gradle
+++ b/consumer/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'consumer'

--- a/data-collector/build.gradle
+++ b/data-collector/build.gradle
@@ -5,8 +5,17 @@ plugins {
     id 'application'
 }
 
+bootJar {
+    enabled = true
+}
+jar {
+    enabled = false
+}
+
 group = 'kr.cs.interdata'
 version = '0.0.1-SNAPSHOT'
+
+
 
 java {
     toolchain {
@@ -50,6 +59,7 @@ repositories {
 }
 
 dependencies {
+    implementation project(':producer')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
     compileOnly 'org.projectlombok:lombok'

--- a/data-collector/docker-compose.yml
+++ b/data-collector/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  data-collector:
+    build: .
+    environment:
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+    networks:
+      - metrics-backend_default
+
+networks:
+  metrics-backend_default:
+    external: true

--- a/data-collector/settings.gradle
+++ b/data-collector/settings.gradle
@@ -1,2 +1,0 @@
-include 'data-collector'
-rootProject.name = 'data-collector'

--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
@@ -1,4 +1,120 @@
 package kr.cs.interdata.datacollector;
+
+import com.google.gson.Gson;
+import kr.cs.interdata.producer.service.KafkaProducerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+@SpringBootApplication(scanBasePackages = "kr.cs.interdata")
+public class DataCollectorApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DataCollectorRunner.class, args);
+    }
+}
+**/
+@SpringBootApplication(scanBasePackages = "kr.cs.interdata")
+public class DataCollectorApplication {
+    public static void main(String[] args) {
+        SpringApplication app = new SpringApplication(DataCollectorApplication.class);
+        app.setWebApplicationType(org.springframework.boot.WebApplicationType.NONE);
+        app.run(args);
+    }
+}
+@Component
+class DataCollectorRunner implements CommandLineRunner {
+
+    private final KafkaProducerService kafkaProducerService;
+
+    @Autowired
+    public DataCollectorRunner(KafkaProducerService kafkaProducerService) {
+        this.kafkaProducerService = kafkaProducerService;
+    }
+
+    @Override
+    public void run(String... args) {
+        long prevDiskReadBytes = 0;
+        long prevDiskWriteBytes = 0;
+        Map<String, Long> prevNetRecv = new HashMap<>();
+        Map<String, Long> prevNetSent = new HashMap<>();
+        Gson gson = new Gson();
+
+        while (true) {
+            String json = ContainerResourceMonitor.collectContainerResources();
+            Map<String, Object> jsonMap = gson.fromJson(json, Map.class);
+
+            // 디스크 변화량 계산
+            long currDiskReadBytes = ((Number) jsonMap.get("diskReadBytes")).longValue();
+            long currDiskWriteBytes = ((Number) jsonMap.get("diskWriteBytes")).longValue();
+            long deltaDiskRead = currDiskReadBytes - prevDiskReadBytes;
+            long deltaDiskWrite = currDiskWriteBytes - prevDiskWriteBytes;
+
+            // 네트워크 변화량 계산
+            Map<String, Object> network = (Map<String, Object>) jsonMap.get("network");
+            Map<String, Map<String, Object>> netDelta = new HashMap<>();
+            for (String iface : network.keySet()) {
+                Map<String, Object> ifaceMap = (Map<String, Object>) network.get(iface);
+                long currRecv = ((Number) ifaceMap.get("bytesReceived")).longValue();
+                long currSent = ((Number) ifaceMap.get("bytesSent")).longValue();
+                long prevRecv = prevNetRecv.getOrDefault(iface, currRecv);
+                long prevSent = prevNetSent.getOrDefault(iface, currSent);
+                long deltaRecv = currRecv - prevRecv;
+                long deltaSent = currSent - prevSent;
+
+                // 네트워크 속도(Bps, 초당 바이트)
+                long rxBps = deltaRecv / 5;
+                long txBps = deltaSent / 5;
+
+                Map<String, Object> ifaceDelta = new HashMap<>();
+                ifaceDelta.put("rxBytesDelta", deltaRecv);
+                ifaceDelta.put("txBytesDelta", deltaSent);
+                ifaceDelta.put("rxBps", rxBps);
+                ifaceDelta.put("txBps", txBps);
+                netDelta.put(iface, ifaceDelta);
+
+                prevNetRecv.put(iface, currRecv);
+                prevNetSent.put(iface, currSent);
+            }
+
+            // 새로운 JSON에 변화량만 남기고, 누적값/불필요한 값은 제거
+            Map<String, Object> resultJson = new LinkedHashMap<>();
+            resultJson.put("type", jsonMap.get("type"));
+            resultJson.put("containerId", jsonMap.get("containerId"));
+            resultJson.put("cpuUsage", jsonMap.get("cpuUsage"));
+            resultJson.put("memoryUsedBytes", jsonMap.get("memoryUsedBytes"));
+            resultJson.put("diskReadBytesDelta", deltaDiskRead);
+            resultJson.put("diskWriteBytesDelta", deltaDiskWrite);
+            resultJson.put("networkDelta", netDelta);
+
+            String jsonPayload = gson.toJson(resultJson);
+
+            System.out.println("=== 컨테이너 리소스 변화량 수집 결과 ===");
+            System.out.println(jsonPayload);
+
+            // Kafka로 전송
+            kafkaProducerService.routeMessageBasedOnType(jsonPayload);
+
+            // 이전값 갱신
+            prevDiskReadBytes = currDiskReadBytes;
+            prevDiskWriteBytes = currDiskWriteBytes;
+
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                System.out.println("스레드가 인터럽트되었습니다.");
+            }
+        }
+    }
+}
+/**
+package kr.cs.interdata.datacollector;
 import java.io.File;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/LocalHostResourceMonitor.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/LocalHostResourceMonitor.java
@@ -135,6 +135,8 @@ public class LocalHostResourceMonitor {
         //뭔가 이렇게 하면 안될거 같아서 다른 방법 찾아봐야할거 같은..
         //일단 생각해보기
         try {
+
+
             Path path = Paths.get(HOST_ID_FILE);
             if (Files.exists(path)) {
                 return Files.readString(path).trim();

--- a/data-collector/src/main/resources/application.properties
+++ b/data-collector/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=data-collector
 
 server.port = 8001
+spring.kafka.bootstrap-servers=kafka:9092

--- a/producer/settings.gradle
+++ b/producer/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'producer'


### PR DESCRIPTION
### 컨테이너 리소스 정보(CPU, 메모리, 디스크, 네트워크 등)를 수집한 데이터를 Kafka로 전송하는 기능을 구현

####  주요 변경 사항
* KafkaProducerService 연동을 통해 컨테이너 리소스를 Kafka에 전송
* 수집 주기마다 리소스 변화량을 계산하여 Kafka로 전송

####  실행 방법

```bash
# data-collector 디렉토리에서 실행
docker compose up --build
```

> ⚠️ Kafka와 Zookeeper가 **로컬에서 실행 중**이어야 정상 작동함
> 로컬에서 실행중인 Kafka를 사용하는 `docker-compose.yml` 구성을 사용하고 있음

#### 기타 사항

* 다수의 리팩토링 및 로직 보완이 포함되어 있으므로 변경 파일이 많음

#### 실행 결과 예시
![image](https://github.com/user-attachments/assets/bb285e16-420b-42a1-a1e6-7374128b6d6f)

