### PR TITLE
Update docker-compose.yml and ResourceMonitor before restructuring fo…

### DIFF
--- a/data-collector/build.gradle
+++ b/data-collector/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     implementation 'com.github.oshi:oshi-core:6.4.5'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation "com.h2database:h2"
+
+    implementation 'org.apache.kafka:kafka-clients:3.7.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
 }
 
 tasks.named('test') {

--- a/data-collector/docker-compose.yml
+++ b/data-collector/docker-compose.yml
@@ -1,9 +1,58 @@
-version: '3'
+version: '3.8'
 services:
+  zookeeper:
+    image: bitnami/zookeeper:3.9
+    container_name: zookeeper
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+      - "2181:2181"
+    networks:
+      - metrics-backend_default
+
+  kafka:
+    image: bitnami/kafka:3.7
+    container_name: kafka
+    ports:
+      - "9092:9092"      # 컨테이너 내부용 포트
+      - "19092:19092"    # 호스트(PC) 접근용 포트
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      # [듀얼 리스너] 컨테이너 내부/호스트 모두에서 접근 가능하게 리스너 2개 선언 (포트 분리)
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,PLAINTEXT_HOST://:19092
+      # [듀얼 advertised.listeners] 컨테이너 내부는 kafka:9092, 호스트는 host.docker.internal:19092로 안내
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,PLAINTEXT_HOST://host.docker.internal:19092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+    depends_on:
+      - zookeeper
+    networks:
+      - metrics-backend_default
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
   data-collector:
     build: .
     environment:
-      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092  # 컨테이너 내부에서 kafka:9092로 접근
+    depends_on:
+      - kafka
+    networks:
+      - metrics-backend_default
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      - kafka
+    ports:
+      - 8080:8080
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092  # 컨테이너 내부에서 kafka:9092로 접근
+      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:2181
     networks:
       - metrics-backend_default
 

--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/ResourceMonitorDaemon.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/ResourceMonitorDaemon.java
@@ -3,10 +3,138 @@ package kr.cs.interdata.datacollector;
 import com.google.gson.Gson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class ResourceMonitorDaemon {
+    public static void main(String[] args) throws Exception {
+        // Kafka Producer 설정
+        Properties props = new Properties();
+        props.put("bootstrap.servers", "host.docker.internal:19092");
+
+        //props.put("bootstrap.servers", "host.docker.internal:9092");
+        //props.put("bootstrap.servers", "host.docker.internal:9092");
+        //props.put("bootstrap.servers", "localhost:9092"); // Kafka 브로커 주소 (필요시 수정)
+        props.put("acks", "all");
+        props.put("retries", 0);
+        props.put("batch.size", 16384);
+        props.put("linger.ms", 1);
+        props.put("buffer.memory", 33554432);
+        props.put("key.serializer", StringSerializer.class.getName());
+        props.put("value.serializer", StringSerializer.class.getName());
+
+        String topic = "localhost"; // 원하는 토픽명으로 변경 가능
+
+        try (Producer<String, String> producer = new KafkaProducer<>(props)) {
+            LocalHostResourceMonitor monitor = new LocalHostResourceMonitor();
+
+            long prevDiskReadBytes = 0;
+            long prevDiskWriteBytes = 0;
+            Map<String, Long> prevNetRecv = new HashMap<>();
+            Map<String, Long> prevNetSent = new HashMap<>();
+
+            ObjectMapper prettyMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+            while (true) {
+                String jsonStr = monitor.getResourcesAsJson();
+                Map<String, Object> resourceMap = new Gson().fromJson(jsonStr, Map.class);
+
+                // 1. 디스크 변화량 계산
+                long currDiskReadBytes = ((Number) resourceMap.get("diskReadBytes")).longValue();
+                long currDiskWriteBytes = ((Number) resourceMap.get("diskWriteBytes")).longValue();
+                long deltaDiskRead = currDiskReadBytes - prevDiskReadBytes;
+                long deltaDiskWrite = currDiskWriteBytes - prevDiskWriteBytes;
+
+                // 2. 네트워크 변화량 계산
+                Map<String, Object> netInfo = (Map<String, Object>) resourceMap.get("network");
+                Map<String, Map<String, Object>> netDelta = new HashMap<>();
+                for (String iface : netInfo.keySet()) {
+                    Map<String, Object> ifaceInfo = (Map<String, Object>) netInfo.get(iface);
+                    long currRecv = ((Number) ifaceInfo.get("bytesReceived")).longValue();
+                    long currSent = ((Number) ifaceInfo.get("bytesSent")).longValue();
+                    long prevRecv = prevNetRecv.getOrDefault(iface, currRecv);
+                    long prevSent = prevNetSent.getOrDefault(iface, currSent);
+
+                    long deltaRecv = currRecv - prevRecv;
+                    long deltaSent = currSent - prevSent;
+
+                    // 네트워크 속도(Bps, 초당 바이트)
+                    long rxBps = deltaRecv / 5;
+                    long txBps = deltaSent / 5;
+
+                    Map<String, Object> ifaceDelta = new HashMap<>();
+                    ifaceDelta.put("rxBytesDelta", deltaRecv);
+                    ifaceDelta.put("txBytesDelta", deltaSent);
+                    ifaceDelta.put("rxBps", rxBps);
+                    ifaceDelta.put("txBps", txBps);
+                    netDelta.put(iface, ifaceDelta);
+
+                    prevNetRecv.put(iface, currRecv);
+                    prevNetSent.put(iface, currSent);
+                }
+
+                // 3. 필요 없는 누적값(디스크/네트워크) 삭제
+                resourceMap.remove("diskReadBytes");
+                resourceMap.remove("diskWriteBytes");
+                resourceMap.remove("network");
+
+                // 4. 변화량만 추가
+                resourceMap.put("diskReadBytesDelta", deltaDiskRead);
+                resourceMap.put("diskWriteBytesDelta", deltaDiskWrite);
+                resourceMap.put("networkDelta", netDelta);
+
+                // 5. 예쁘게 출력
+                String prettyJson = prettyMapper.writeValueAsString(resourceMap);
+                System.out.println(prettyJson);
+
+                // 6. Kafka로 전송
+                ProducerRecord<String, String> record = new ProducerRecord<>(topic, prettyJson);
+                producer.send(record, (metadata, exception) -> {
+                    if (exception != null) {
+                        System.err.println("Kafka 전송 실패: " + exception.getMessage());
+                    } else {
+                        System.out.println("Kafka 전송 성공: " + metadata.topic() + " offset=" + metadata.offset());
+                    }
+                });
+
+                // 7. 이전값 갱신
+                prevDiskReadBytes = currDiskReadBytes;
+                prevDiskWriteBytes = currDiskWriteBytes;
+
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException ie) {
+                    System.out.println("Interrupted, but monitoring continues.");
+                }
+            }
+        }
+    }
+}
+
+/**package kr.cs.interdata.datacollector;
+
+import com.google.gson.Gson;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.Properties;
+import java.util.concurrent.Future;
 
 public class ResourceMonitorDaemon {
     public static void main(String[] args) throws Exception {
@@ -88,64 +216,4 @@ public class ResourceMonitorDaemon {
         }
     }
 }
-
-       /**
-        //무한 루프 : 5초마다 리소스 데이터 수집 및 출력
-        while (true) {
-            // 현재 리소스 전체 누적값(JSON 문자열) 파싱
-            String jsonStr = monitor.getResourcesAsJson();
-            Map<String, Object> resourceMap = new Gson().fromJson(jsonStr, Map.class);
-
-            // 2. 디스크 변화량 계산
-            long currDiskReadBytes = ((Number) resourceMap.get("diskReadBytes")).longValue();
-            long currDiskWriteBytes = ((Number) resourceMap.get("diskWriteBytes")).longValue();
-            long deltaDiskRead = currDiskReadBytes - prevDiskReadBytes;
-            long deltaDiskWrite = currDiskWriteBytes - prevDiskWriteBytes;
-
-            // 3. 네트워크 변화량 계산
-            Map<String, Object> netInfo = (Map<String, Object>) resourceMap.get("network");
-            Map<String, Map<String, Object>> netDelta = new HashMap<>();
-            for (String iface : netInfo.keySet()) {
-                Map<String, Object> ifaceInfo = (Map<String, Object>) netInfo.get(iface);
-                long currRecv = ((Number) ifaceInfo.get("bytesReceived")).longValue();
-                long currSent = ((Number) ifaceInfo.get("bytesSent")).longValue();
-                long prevRecv = prevNetRecv.getOrDefault(iface, currRecv);
-                long prevSent = prevNetSent.getOrDefault(iface, currSent);
-
-                long deltaRecv = currRecv - prevRecv;
-                long deltaSent = currSent - prevSent;
-
-                Map<String, Object> ifaceDelta = new HashMap<>();
-                ifaceDelta.put("rxBytesDelta", deltaRecv);
-                ifaceDelta.put("txBytesDelta", deltaSent);
-                netDelta.put(iface, ifaceDelta);
-
-                prevNetRecv.put(iface, currRecv);
-                prevNetSent.put(iface, currSent);
-            }
-
-            // 4. 최종 JSON에 변화량 정보 추가
-            resourceMap.put("diskReadBytesDelta", deltaDiskRead);
-            resourceMap.put("diskWriteBytesDelta", deltaDiskWrite);
-            resourceMap.put("networkDelta", netDelta);
-
-            // 5. 예쁘게 출력(Pretty Print)
-            String prettyJson = prettyMapper.writeValueAsString(resourceMap);
-            System.out.println("=== 로컬 호스트 리소스 수집 결과 ===");
-            System.out.println(prettyJson);
-
-            // 6. 이전값 갱신
-            prevDiskReadBytes = currDiskReadBytes;
-            prevDiskWriteBytes = currDiskWriteBytes;
-
-            try {
-                Thread.sleep(5000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                System.out.println("스레드가 인터럽트되었습니다.");
-                break;
-            }
-        }
-    }
-}
-**/
+ **/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,14 @@ services:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
 
+  data-collector:
+    build: .
+    container_name: data-collector
+    depends_on:
+      - kafka
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+
 #  consumer:
 #    build:
 #      context: ./consumer

--- a/producer/build.gradle
+++ b/producer/build.gradle
@@ -1,7 +1,15 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.4'
+    //id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'java-library'
+}
+
+bootJar {
+    enabled = false
+}
+jar {
+    enabled = true
 }
 
 group = 'kr.cs.interdata'
@@ -37,6 +45,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'org.mockito:mockito-core'
+    implementation 'com.h2database:h2' // 또는 testImplementation
 }
 
 tasks.named('test') {

--- a/producer/src/main/java/kr/cs/interdata/producer/service/KafkaProducerService.java
+++ b/producer/src/main/java/kr/cs/interdata/producer/service/KafkaProducerService.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonParser;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.protocol.Message;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
### docker-compose 파일 내용 수정 및 ResourceMonitorDaemon에서 수집한 리소스 카프카로 보내기 위해서 코드 수정

- 컨테이너 리소스는 컨테이너에서 돌려야 하고 localhost 리소스 수집하는거는 로컬에서 돌린 다음에 카프카로 줘야하는데 이 방법이 다르니까 한 폴더 안에서 처리할려고 하니 헷갈려서 data-collector 폴더를 2개로 나눌 생각
- 나누기 전에 작업했던거 push함.
- 아직 로컬호스트는 카프카에 연결 못했음
- docker-compose.yml도 data-collector 폴더 안에꺼는 지우고 metrics-backend안에 docker-compose.yml을 수정할 예정
