### PR TITLE
feat: Exclude self-monitoring in data-collector container via EXCLUDE…

### DIFF
--- a/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
+++ b/data-collector/src/main/java/kr/cs/interdata/datacollector/DataCollectorApplication.java
@@ -11,6 +11,10 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
 
 /**
 @SpringBootApplication(scanBasePackages = "kr.cs.interdata")
@@ -30,7 +34,8 @@ public class DataCollectorApplication {
 }
 @Component
 class DataCollectorRunner implements CommandLineRunner {
-
+    private static final Logger logger = LoggerFactory.getLogger(DataCollectorRunner.class); // 로거 선언
+    //private static final Logger logger = LoggerFactory.getLogger(DataCollectorRunner.class);
     private final KafkaProducerService kafkaProducerService;
 
     @Autowired
@@ -47,6 +52,14 @@ class DataCollectorRunner implements CommandLineRunner {
         Gson gson = new Gson();
 
         while (true) {
+            // 자기 자신은 수집과 전송하지 않음
+            String excludeSelf = System.getenv("EXCLUDE_SELF");
+            if ("true".equalsIgnoreCase(excludeSelf)) {
+                logger.info("자기 자신 컨테이너이므로 리소스 수집/전송을 건너뜁니다.");
+                //logger.info("자기 자신 컨테이너이므로 리소스 수집/전송을 건너뜁니다.");
+                try { Thread.sleep(5000); } catch (InterruptedException e) {}
+                continue;
+            }
             String json = ContainerResourceMonitor.collectContainerResources();
             Map<String, Object> jsonMap = gson.fromJson(json, Map.class);
 


### PR DESCRIPTION
### EXCLUDE_SELF 환경변수로 data-collector 컨테이너의 자기 자신 모니터링 제외 기능 추가

---

### 주요 변경 내용

- data-collector 컨테이너가 자신의 리소스 사용량을 수집 및 전송하지 않도록 하는 로직을 추가
- `EXCLUDE_SELF` 환경변수를 `true`로 설정하면, data-collector가 자기 자신의 리소스 수집 및 카프카 전송을 건너뜀

### 왜 자기 자신 모니터링을 제외하는가
-> 내가 감시하는 컨테이너 말고도 계속 값이 측정되고 값은 계속 -1이 뜨길래 이 부분을 수정하다가 자기 자신을 모니터링 해야하는지 궁금해서 일단 gpt한테 물어봤음.. 다른 자료들도 더 찾아볼 예정
- **순환 참조 방지:** 수집기가 자기 자신을 모니터링하면 불필요한 순환 구조가 생길 수 있음
- **데이터 중복/혼란 방지:** 수집기 자신의 리소스까지 포함하면 전체 통계에 혼동을 줄 수 있음

### 동작 방식
- docker-compose.yml에서   data-collector->environment -> EXCLUDE_SELF 값이 `true`이면, data-collector는 자기 자신의 리소스 수집/전송을 건너뛰고 로그만 남김.
- 다른 컨테이너의 리소스는 기존과 동일하게 정상적으로 수집/전송됨.
