### PR TITLE
consumer 모듈 Docker 컨테이너화 및 docker-compose 통합

### DIFF
--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,5 +1,4 @@
-FROM eclipse-temurin:21-jdk
+FROM eclipse-temurin:21-jre
 WORKDIR /app
-COPY build/libs/*.jar app.jar
-EXPOSE 8000
+COPY build/libs/consumer-0.0.1-SNAPSHOT.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/consumer/src/main/java/kr/cs/interdata/consumer/config/ListenerContainerConfiguration.java
+++ b/consumer/src/main/java/kr/cs/interdata/consumer/config/ListenerContainerConfiguration.java
@@ -24,8 +24,8 @@ public class ListenerContainerConfiguration {
     public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, String>> customContainerFactory() {
         Map<String, Object> props = new HashMap<>();
 
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9094");     // Kafka 서버 주소 (브로커 리스트). 클러스터에 처음 연결할 때 사용하는 주소
-        //props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9094");           // kafka 서버 주소 -> container용
+        //props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9094");     // Kafka 서버 주소 (브로커 리스트). 클러스터에 처음 연결할 때 사용하는 주소
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");           // kafka 서버 주소 -> container용
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);  // 메시지 키를 역직렬화할 클래스 (여기선 문자열로 처리)
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);    // 메시지 값을 역직렬화할 클래스 (여기서도 문자열)
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "data-stroage-group");    // 이 Consumer가 속한 Consumer Group ID (같은 Group ID면 하나만 처리함)

--- a/consumer/src/main/resources/application-docker.yml
+++ b/consumer/src/main/resources/application-docker.yml
@@ -1,3 +1,0 @@
-spring:
-  kafka:
-    bootstrap-servers: kafka:9092

--- a/consumer/src/main/resources/application.properties
+++ b/consumer/src/main/resources/application.properties
@@ -2,6 +2,7 @@ spring.application.name=consumer
 
 # Server Settings
 server.port=8000
+server.address=0.0.0.0
 spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVER}
 
 # Consumer settings

--- a/consumer/src/main/resources/properties/env.properties
+++ b/consumer/src/main/resources/properties/env.properties
@@ -2,21 +2,23 @@ GROUP_ID=data-stroage-group
 
 # Bootstrap server
 # 1. server = localhost
-BOOTSTRAP_SERVER=localhost:9094
+#BOOTSTRAP_SERVER=localhost:9094
 # 2. server = container
-#BOOTSTRAP_SERVER=kafka:9092
+BOOTSTRAP_SERVER=kafka:9092
 
-#KAFKA_TOPIC_HOST=localhost
-#KAFKA_TOPIC_CONTAINER=container
-KAFKA_TOPIC_HOST=monitoring.host.dev.json
-KAFKA_TOPIC_CONTAINER=monitoring.container.dev.json
+KAFKA_TOPIC_HOST=localhost
+KAFKA_TOPIC_CONTAINER=container
+#KAFKA_TOPIC_HOST=monitoring.host.dev.json
+#KAFKA_TOPIC_CONTAINER=monitoring.container.dev.json
 KAFKA_GROUP_ID_STORAGE_GROUP=data-storage-group
 
 # Base "URL" for API transmit
 # 1. my domain
 #API_BASE_URL=http://domain:8081
 # 2. localhost
-API_BASE_URL=http://localhost:8004
+#API_BASE_URL=http://localhost:8004
+# 3. docker -> localhost
+API_BASE_URL=http://host.docker.internal:8004
 
 # URL for websocket
 SOCKET_ALLOWED_ADDR=*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,19 @@ services:
     environment:
       SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
 
+  consumer:
+    build:
+      context: ./consumer   # consumer 폴더 기준으로 빌드
+    container_name: consumer
+    depends_on:
+      - kafka
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - 8000:8000
+
 networks:
   default:
     name: metrics-backend_default


### PR DESCRIPTION
consumer 모듈에 Dockerfile을 추가하여 컨테이너 이미지로 빌드할 수 있도록 했습니다.

docker-compose.yml에 consumer 서비스 정의 및 포트 매핑, 환경변수, 네트워크 설정을 추가하여 전체 서비스와 통합 실행이 가능하도록 구성했습니다.

코드 수정 및 빌드 후 docker-compose up --build -d 명령만으로 모든 서비스가 일관된 환경에서 실행됩니다.

기존에 직접 컨테이너를 띄우던 방식을 제거하고, docker-compose 기반의 통합 관리로 운영 효율성과 일관성을 개선하였습니다.