### PR TITLE
fix: 배포 환경에 맞게 IP 및 docker-compose.yml 설정 수정

### DIFF
--- a/consumer/.gitignore
+++ b/consumer/.gitignore
@@ -38,6 +38,6 @@ out/
 
 ### env ###
 .env
-/src/main/resources/properties/env.properties
+/src/main/resources/properties/
 env.properties
 

--- a/consumer/src/main/resources/properties/env.properties
+++ b/consumer/src/main/resources/properties/env.properties
@@ -14,15 +14,16 @@ KAFKA_GROUP_ID_STORAGE_GROUP=data-storage-group
 
 # Base "URL" for API transmit
 # 1. my domain
-#API_BASE_URL=http://domain:8081
+API_BASE_URL=http://13.125.19.139:8004
 # 2. localhost
 #API_BASE_URL=http://localhost:8004
 # 3. docker -> localhost
 # Right now we are running api-backend locally and using http://host.docker.internal:8004,
 # but when deploying, we use the deployment IP instead of host.doicker.internal.
-API_BASE_URL=http://host.docker.internal:8004
+#API_BASE_URL=http://host.docker.internal:8004
 
 # URL for websocket
 # Currently, we are using '*' as we are under development,
 # but after deployment, we plan to use 'domain or ip address'.
-SOCKET_ALLOWED_ADDR=*
+#SOCKET_ALLOWED_ADDR=*
+SOCKET_ALLOWED_ADDR=http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 2181:2181
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
-      ALLOW_ANONYMOUS_LOGIN: yes
+      ALLOW_ANONYMOUS_LOGIN: "yes"
 
   kafka:
     image: bitnami/kafka:3.7.0
@@ -16,8 +16,8 @@ services:
     ports:
       - 9094:9094
     environment:
-      ALLOW_PLAINTEXT_LISTENER: yes
-      KAFKA_ENABLE_KRAFT: no
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_ENABLE_KRAFT: "no"
       KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,EXTERNAL://:9094
       KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094


### PR DESCRIPTION
## 변경 사항
- 배포 환경(공인 IP 등)에 맞춰 환경변수 및 설정 파일(docker-compose.yml) 수정
- 서비스별 포트 및 네트워크 설정을 운영 환경에 맞게 업데이트
- 개발용 설정 일부 제거, 운영 환경에서 필요한 값으로 최적화

## 배포 시 유의사항
- 변경된 IP 및 포트가 실제 서버 환경과 일치하는지 확인 필요
- docker-compose up -d --build로 배포 시 정상 동작 확인 바람